### PR TITLE
Set VERAPP_EXIT_FAILURE_ON_STDERR_WRAPPER executable in VeraPPUtilities.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,4 @@
 # can import. This will ensure that the verapp_exit_failure_on_stderr
 # wrapper gets built
 
-set (VERAPP_EXIT_FAILURE_ON_STDERR_WRAPPER_EXECUTABLE
-     veracpp_exit_failure_on_stderr_wrapper)
-
 add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/VeraPPUtilities.cmake
+++ b/VeraPPUtilities.cmake
@@ -19,6 +19,9 @@
 #
 # See LICENCE.md for Copyright info
 
+set (VERAPP_EXIT_FAILURE_ON_STDERR_WRAPPER_EXECUTABLE
+     veracpp_exit_failure_on_stderr_wrapper)
+
 function (verapp_list_files_in_external_directory DIRECTORY MATCH RETURN_FILES)
     find_program (_verapp_ls ls)
     mark_as_advanced (_verapp_ls)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,8 @@
 #
 # See LICENCE.md for Copyright information
 
+include (VeraPPUtilities)
+
 find_package (Boost 1.49 REQUIRED COMPONENTS iostreams)
 
 set (CMAKE_CXX_FLAGS "-std=c++0x -Wall -Werror" ${CMAKE_CXX_FLAGS})


### PR DESCRIPTION
We need it to be set in that scope as we use it in that file. Just include
it in src/
