### PR TITLE
Execute vera++ PRE_LINK.

### DIFF
--- a/VeraPPUtilities.cmake
+++ b/VeraPPUtilities.cmake
@@ -293,7 +293,7 @@ function (_verapp_profile_check_sources_conformance_for_target VERAPP_DIRECTORY
     # just refers to the list name and not the list itself
     foreach (_source ${${SOURCES_VAR}})
         add_custom_command (TARGET ${TARGET}
-                            POST_BUILD
+                            PRE_LINK
                             COMMAND
                             ${VERAPP_EXECUTABLE}
                             ARGS


### PR DESCRIPTION
This ensures that it happens after all the files have been
generated for a particular target, but also ensures that if
errors are generated as a result of the vera++ checks then
the target won't be considered as successfully built.
